### PR TITLE
Changed method names from readUInt64 to readUint64 

### DIFF
--- a/.project
+++ b/.project
@@ -1,3 +1,3 @@
 {
-	'srcDirectory' : '/'
+	'srcDirectory' : ''
 }

--- a/Protobuf-Core-Tests/PBCodedStreamTest.class.st
+++ b/Protobuf-Core-Tests/PBCodedStreamTest.class.st
@@ -48,24 +48,34 @@ PBCodedStreamTest >> testFloat [
 
 { #category : #tests }
 PBCodedStreamTest >> testIntegers32 [
-
-	self testWriter: [ :output |
+	self
+		testWriter: [ :output | 
 			output writeField: 1 int32: 12345.
 			output writeField: 2 uint32: 12345.
 			output writeField: 3 sint32: -12345.
 			output writeField: 4 fixed32: 12345.
 			output writeField: 5 sfixed32: -12345 ]
-		reader: [ :input |
-			self assert: input readTag equals: (input coder makeTag: 1 wireType: WireTypeVarint).
+		reader: [ :input | 
+			self
+				assert: input readTag
+				equals: (input coder makeTag: 1 wireType: WireTypeVarint).
 			self assert: input readInt32 equals: 12345.
-			self assert: input readTag equals: (input coder makeTag: 2 wireType: WireTypeVarint).
-			self assert: input readUInt32 equals: 12345.
-			self assert: input readTag equals: (input coder makeTag: 3 wireType: WireTypeVarint).
-			self assert: input readSInt32 equals: -12345.
-			self assert: input readTag equals: (input coder makeTag: 4 wireType: WireType32bit).
+			self
+				assert: input readTag
+				equals: (input coder makeTag: 2 wireType: WireTypeVarint).
+			self assert: input readUint32 equals: 12345.
+			self
+				assert: input readTag
+				equals: (input coder makeTag: 3 wireType: WireTypeVarint).
+			self assert: input readSint32 equals: -12345.
+			self
+				assert: input readTag
+				equals: (input coder makeTag: 4 wireType: WireType32bit).
 			self assert: input readFixed32 equals: 12345.
-			self assert: input readTag equals: (input coder makeTag: 5 wireType: WireType32bit).
-			self assert: input readSFixed32 equals: -12345 ]
+			self
+				assert: input readTag
+				equals: (input coder makeTag: 5 wireType: WireType32bit).
+			self assert: input readSfixed32 equals: -12345 ]
 ]
 
 { #category : #tests }
@@ -81,13 +91,13 @@ PBCodedStreamTest >> testIntegers64 [
 			self assert: input readTag equals: (input coder makeTag: 1 wireType: WireTypeVarint).
 			self assert: input readInt64 equals: 12345.
 			self assert: input readTag equals: (input coder makeTag: 2 wireType: WireTypeVarint).
-			self assert: input readUInt64 equals: 12345.
+			self assert: input readUint64 equals: 12345.
 			self assert: input readTag equals: (input coder makeTag: 3 wireType: WireTypeVarint).
-			self assert: input readSInt64 equals: -12345.
+			self assert: input readSint64 equals: -12345.
 			self assert: input readTag equals: (input coder makeTag: 4 wireType: WireType64bit).
 			self assert: input readFixed64 equals: 12345.
 			self assert: input readTag equals: (input coder makeTag: 5 wireType: WireType64bit).
-			self assert: input readSFixed64 equals: -12345 ]
+			self assert: input readSfixed64 equals: -12345 ]
 ]
 
 { #category : #tests }

--- a/Protobuf-Core-Tests/PBSmalltalkClassInfoMessage.class.st
+++ b/Protobuf-Core-Tests/PBSmalltalkClassInfoMessage.class.st
@@ -76,7 +76,7 @@ PBSmalltalkClassInfoMessage >> readFrom: input [
 		add: 18 -> [ superclassName := input readString ];
 		add: 26 -> [ subclassNameList add: input readString ];
 		add: 34 -> [ instVarNameList add: input readString ];
-		add: 40 -> [ infoSize := input readUInt64 ];
+		add: 40 -> [ infoSize := input readUint64 ];
 		add: 72 -> [ infoIndexList add: input readInt32 ];
 		add: 74 -> [ infoIndexList addAll: input readInt32List ];
 		add: 80 -> [ infoFinal := input readBool ];

--- a/Protobuf-Core/PBCodedReadStream.class.st
+++ b/Protobuf-Core/PBCodedReadStream.class.st
@@ -64,6 +64,13 @@ PBCodedReadStream >> readBoolList [
 ]
 
 { #category : #'write and read' }
+PBCodedReadStream >> readBytes [
+	| byteCount |
+	byteCount := coder readVarintRaw: stream.
+	^ stream next: byteCount 
+]
+
+{ #category : #'write and read' }
 PBCodedReadStream >> readDouble [
 	
 	^coder readDouble: stream

--- a/Protobuf-Core/PBCodedReadStream.class.st
+++ b/Protobuf-Core/PBCodedReadStream.class.st
@@ -200,13 +200,13 @@ PBCodedReadStream >> readMessage: aMessageClass [
 ]
 
 { #category : #'write and read' }
-PBCodedReadStream >> readSFixed32 [
+PBCodedReadStream >> readSfixed32 [
 	
 	^coder readSFixed32: stream
 ]
 
 { #category : #'write and read' }
-PBCodedReadStream >> readSFixed32List [
+PBCodedReadStream >> readSfixed32List [
 
 	| length list |
 	
@@ -222,13 +222,13 @@ PBCodedReadStream >> readSFixed32List [
 ]
 
 { #category : #'write and read' }
-PBCodedReadStream >> readSFixed64 [
+PBCodedReadStream >> readSfixed64 [
 	
 	^coder readSFixed64: stream
 ]
 
 { #category : #'write and read' }
-PBCodedReadStream >> readSFixed64List [
+PBCodedReadStream >> readSfixed64List [
 
 	| length size list |
 	
@@ -245,13 +245,13 @@ PBCodedReadStream >> readSFixed64List [
 ]
 
 { #category : #'write and read' }
-PBCodedReadStream >> readSInt32 [
+PBCodedReadStream >> readSint32 [
 	
 	^coder decodeZigZag32: (coder readVarintRaw: stream)
 ]
 
 { #category : #'write and read' }
-PBCodedReadStream >> readSInt64 [
+PBCodedReadStream >> readSint64 [
 	
 	^coder decodeZigZag64: (coder readVarintRaw: stream)
 ]
@@ -277,13 +277,12 @@ PBCodedReadStream >> readTag [
 ]
 
 { #category : #'write and read' }
-PBCodedReadStream >> readUInt32 [
-	
-	^self coder readVarint32: stream
+PBCodedReadStream >> readUint32 [
+	^ self coder readVarint32: stream
 ]
 
 { #category : #'write and read' }
-PBCodedReadStream >> readUInt64 [
+PBCodedReadStream >> readUint64 [
 	
 	^self coder readVarintRaw: stream
 ]


### PR DESCRIPTION
(and similar for other types) since code generation only capitalized first letter of type name.

Tests updated to match.